### PR TITLE
Feature/allow non ascii varnames

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
@@ -24,9 +24,16 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.util.Log;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class FragmentResolver {
+
+    protected final String encoding;
+
+    public FragmentResolver(String encoding) {
+        this.encoding = encoding;
+    }
 
     public JsonNode resolve(JsonNode tree, String path) {
 
@@ -41,9 +48,9 @@ public class FragmentResolver {
         } else {
             String part = path.remove(0);
             try {
-                // TODO: get output encoding from config
-                part = URLDecoder.decode(part, "UTF-8");
+                part = URLDecoder.decode(part, encoding);
             } catch (UnsupportedEncodingException e) {
+                Log.e("FragmentResolver", "Could not decode path part from encoding " + encoding);
                 e.printStackTrace();
             }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/FragmentResolver.java
@@ -19,6 +19,8 @@ package org.jsonschema2pojo;
 import static java.util.Arrays.*;
 import static org.apache.commons.lang3.StringUtils.*;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +40,12 @@ public class FragmentResolver {
             return tree;
         } else {
             String part = path.remove(0);
+            try {
+                // TODO: get output encoding from config
+                part = URLDecoder.decode(part, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
 
             if (tree.isArray()) {
                 try {

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/Jsonschema2Pojo.java
@@ -114,7 +114,7 @@ public class Jsonschema2Pojo {
     }
 
     private static String childQualifiedName(String parentQualifiedName, String childSimpleName) {
-        String safeChildName = childSimpleName.replaceAll(NameHelper.ILLEGAL_CHARACTER_REGEX, "_");
+        String safeChildName = NameHelper.replaceIllegalCharacters(childSimpleName);
         return isEmpty(parentQualifiedName) ? safeChildName : parentQualifiedName + "." + safeChildName;
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/SchemaStore.java
@@ -29,8 +29,13 @@ public class SchemaStore {
 
     protected Map<URI, Schema> schemas = new HashMap<URI, Schema>();
 
-    protected FragmentResolver fragmentResolver = new FragmentResolver();
-    protected ContentResolver contentResolver = new ContentResolver();
+    protected FragmentResolver fragmentResolver;
+    protected ContentResolver contentResolver;
+
+    public SchemaStore(GenerationConfig config) {
+        this.fragmentResolver = new FragmentResolver(config.getOutputEncoding());
+        this.contentResolver = new ContentResolver();
+    }
 
     /**
      * Create or look up a new schema which has the given ID and read the

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/RuleFactory.java
@@ -53,13 +53,11 @@ public class RuleFactory {
      * @param annotator
      *            the annotator used to mark up Java types with any annotations
      *            that are required to build JSON compatible types
-     * @param schemaStore
-     *            the object used by this factory to get and store schemas
      */
-    public RuleFactory(GenerationConfig generationConfig, Annotator annotator, SchemaStore schemaStore) {
+    public RuleFactory(GenerationConfig generationConfig, Annotator annotator) {
         this.generationConfig = generationConfig;
         this.annotator = annotator;
-        this.schemaStore = schemaStore;
+        this.schemaStore = new SchemaStore(generationConfig);
         this.nameHelper = new NameHelper(generationConfig);
     }
 
@@ -69,7 +67,7 @@ public class RuleFactory {
      * @see DefaultGenerationConfig
      */
     public RuleFactory() {
-        this(new DefaultGenerationConfig(), new Jackson2Annotator(), new SchemaStore());
+        this(new DefaultGenerationConfig(), new Jackson2Annotator());
     }
 
     /**

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -22,7 +22,8 @@ import com.sun.codemodel.JType;
 import org.apache.commons.lang3.text.WordUtils;
 import org.jsonschema2pojo.GenerationConfig;
 
-import static java.lang.Character.isDigit;
+import static java.lang.Character.isJavaIdentifierPart;
+import static java.lang.Character.isJavaIdentifierStart;
 import static javax.lang.model.SourceVersion.isKeyword;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.containsAny;
@@ -30,25 +31,28 @@ import static org.apache.commons.lang3.StringUtils.remove;
 
 public class NameHelper {
 
-    public static final String ILLEGAL_CHARACTER_REGEX = "[^0-9a-zA-Z_$]";
-
     private final GenerationConfig generationConfig;
 
     public NameHelper(GenerationConfig generationConfig) {
         this.generationConfig = generationConfig;
     }
 
-    public String replaceIllegalCharacters(String name) {
-        return name.replaceAll(ILLEGAL_CHARACTER_REGEX, "_");
+    public static String replaceIllegalCharacters(String name) {
+        for (char character: name.toCharArray()) {
+            if (!Character.isJavaIdentifierPart(character)) {
+                name = name.replace(String.valueOf(character), "_");
+            }
+        }
+
+        if (!Character.isJavaIdentifierStart(name.charAt(0))) {
+            name = "_" + name;
+        }
+
+        return name;
     }
 
     public String normalizeName(String name) {
         name = capitalizeTrailingWords(name);
-
-        if (isDigit(name.charAt(0))) {
-            name = "_" + name;
-        }
-
         return name;
     }
 

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/util/NameHelper.java
@@ -22,8 +22,6 @@ import com.sun.codemodel.JType;
 import org.apache.commons.lang3.text.WordUtils;
 import org.jsonschema2pojo.GenerationConfig;
 
-import static java.lang.Character.isJavaIdentifierPart;
-import static java.lang.Character.isJavaIdentifierStart;
 import static javax.lang.model.SourceVersion.isKeyword;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.containsAny;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/FragmentResolverTest.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class FragmentResolverTest {
 
-    private FragmentResolver resolver = new FragmentResolver();
+    private FragmentResolver resolver = new FragmentResolver("UTF-8");
 
     @Test
     public void hashResolvesToRoot() {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/SchemaStoreTest.java
@@ -31,12 +31,14 @@ import com.sun.codemodel.JType;
 
 public class SchemaStoreTest {
 
+    protected static final GenerationConfig config = new DefaultGenerationConfig();
+
     @Test
     public void createWithAbsolutePath() throws URISyntaxException {
 
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        Schema schema = new SchemaStore().create(schemaUri);
+        Schema schema = new SchemaStore(config).create(schemaUri);
 
         assertThat(schema, is(notNullValue()));
         assertThat(schema.getId(), is(equalTo(schemaUri)));
@@ -50,7 +52,7 @@ public class SchemaStoreTest {
 
         URI addressSchemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        SchemaStore schemaStore = new SchemaStore();
+        SchemaStore schemaStore = new SchemaStore(config);
         Schema addressSchema = schemaStore.create(addressSchemaUri);
         Schema enumSchema = schemaStore.create(addressSchema, "enum.json");
 
@@ -67,7 +69,7 @@ public class SchemaStoreTest {
 
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        SchemaStore schemaStore = new SchemaStore();
+        SchemaStore schemaStore = new SchemaStore(config);
         Schema addressSchema = schemaStore.create(schemaUri);
         Schema selfRefSchema = schemaStore.create(addressSchema, "#");
 
@@ -80,7 +82,7 @@ public class SchemaStoreTest {
 
         URI schemaUri = getClass().getResource("/schema/embeddedRef.json").toURI();
 
-        SchemaStore schemaStore = new SchemaStore();
+        SchemaStore schemaStore = new SchemaStore(config);
         Schema topSchema = schemaStore.create(schemaUri);
         Schema embeddedSchema = schemaStore.create(topSchema, "#/definitions/embedded");
         Schema selfRefSchema = schemaStore.create(embeddedSchema, "#");
@@ -94,7 +96,7 @@ public class SchemaStoreTest {
 
         URI addressSchemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        SchemaStore schemaStore = new SchemaStore();
+        SchemaStore schemaStore = new SchemaStore(config);
         Schema addressSchema = schemaStore.create(addressSchemaUri);
         Schema innerSchema = schemaStore.create(addressSchema, "#/properties/post-office-box");
 
@@ -112,7 +114,7 @@ public class SchemaStoreTest {
 
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        SchemaStore schemaStore = new SchemaStore();
+        SchemaStore schemaStore = new SchemaStore(config);
 
         Schema schema1 = schemaStore.create(schemaUri);
 
@@ -130,7 +132,7 @@ public class SchemaStoreTest {
 
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        Schema schema = new SchemaStore().create(schemaUri);
+        Schema schema = new SchemaStore(config).create(schemaUri);
 
         schema.setJavaTypeIfEmpty(firstClass);
         assertThat(schema.getJavaType(), is(equalTo(firstClass)));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/example/Example.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/example/Example.java
@@ -47,7 +47,7 @@ public class Example {
             }
         };
 
-        SchemaMapper mapper = new SchemaMapper(new RuleFactory(config, new Jackson2Annotator(), new SchemaStore()), new SchemaGenerator());
+        SchemaMapper mapper = new SchemaMapper(new RuleFactory(config, new Jackson2Annotator()), new SchemaGenerator());
         mapper.generate(codeModel, "ClassName", "com.example", source);
 
         codeModel.build(new File("output"));

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/ArrayRuleTest.java
@@ -39,7 +39,7 @@ import com.sun.codemodel.JPackage;
 public class ArrayRuleTest {
 
     private final GenerationConfig config = mock(GenerationConfig.class);
-    private final ArrayRule rule = new ArrayRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    private final ArrayRule rule = new ArrayRule(new RuleFactory(config, new NoopAnnotator()));
 
     @Test
     public void arrayWithUniqueItemsProducesSet() {

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/EnumRuleTest.java
@@ -59,7 +59,6 @@ public class EnumRuleTest {
 
         Answer<String> firstArgAnswer = new FirstArgAnswer<String>();
         when(nameHelper.getFieldName(anyString(), any(JsonNode.class))).thenAnswer(firstArgAnswer);
-        when(nameHelper.replaceIllegalCharacters(anyString())).thenAnswer(firstArgAnswer);
         when(nameHelper.normalizeName(anyString())).thenAnswer(firstArgAnswer);
 
         JPackage jpackage = new JCodeModel()._package(getClass().getPackage().getName());

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleJodaTest.java
@@ -43,7 +43,7 @@ import org.joda.time.LocalTime;
 public class FormatRuleJodaTest {
 
     private GenerationConfig config = mock(GenerationConfig.class);
-    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator()));
 
     private final String formatValue;
     private final Class<?> expectedType;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/FormatRuleTest.java
@@ -42,7 +42,7 @@ import com.sun.codemodel.JType;
 public class FormatRuleTest {
 
     private GenerationConfig config = mock(GenerationConfig.class);
-    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator(), new SchemaStore()));
+    private FormatRule rule = new FormatRule(new RuleFactory(config, new NoopAnnotator()));
 
     private final String formatValue;
     private final Class<?> expectedType;

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/RuleFactoryImplTest.java
@@ -75,20 +75,9 @@ public class RuleFactoryImplTest {
 
         GenerationConfig mockGenerationConfig = mock(GenerationConfig.class);
 
-        RuleFactory ruleFactory = new RuleFactory(mockGenerationConfig, new NoopAnnotator(), new SchemaStore());
+        RuleFactory ruleFactory = new RuleFactory(mockGenerationConfig, new NoopAnnotator());
 
         assertThat(ruleFactory.getGenerationConfig(), is(sameInstance(mockGenerationConfig)));
-
-    }
-
-    @Test
-    public void schemaStoreIsReturned() {
-
-        SchemaStore mockSchemaStore = mock(SchemaStore.class);
-
-        RuleFactory ruleFactory = new RuleFactory(new DefaultGenerationConfig(), new NoopAnnotator(), mockSchemaStore);
-
-        assertThat(ruleFactory.getSchemaStore(), is(sameInstance(mockSchemaStore)));
 
     }
 

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/rules/SchemaRuleTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.jsonschema2pojo.DefaultGenerationConfig;
+import org.jsonschema2pojo.GenerationConfig;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -44,6 +46,8 @@ public class SchemaRuleTest {
 
     private RuleFactory mockRuleFactory = mock(RuleFactory.class);
     private SchemaRule rule = new SchemaRule(mockRuleFactory);
+    private GenerationConfig config = new DefaultGenerationConfig();
+    private SchemaStore store = new SchemaStore(config);
 
     @Test
     public void refsToOtherSchemasAreLoaded() throws URISyntaxException, JClassAlreadyExistsException {
@@ -57,7 +61,7 @@ public class SchemaRuleTest {
 
         TypeRule mockTypeRule = mock(TypeRule.class);
         when(mockRuleFactory.getTypeRule()).thenReturn(mockTypeRule);
-        when(mockRuleFactory.getSchemaStore()).thenReturn(new SchemaStore());
+        when(mockRuleFactory.getSchemaStore()).thenReturn(store);
 
         ArgumentCaptor<JsonNode> captureJsonNode = ArgumentCaptor.forClass(JsonNode.class);
         ArgumentCaptor<Schema> captureSchema = ArgumentCaptor.forClass(Schema.class);
@@ -105,7 +109,7 @@ public class SchemaRuleTest {
 
         URI schemaUri = getClass().getResource("/schema/address.json").toURI();
 
-        SchemaStore schemaStore = new SchemaStore();
+        SchemaStore schemaStore = new SchemaStore(config);
         Schema schema = schemaStore.create(schemaUri);
         schema.setJavaType(previouslyGeneratedType);
 


### PR DESCRIPTION
Modifications for Unicode support:
- Allow non-ASCII characters in variable names, to support lookup by introspection (accept any valid Java identifier)
- Decode ref URIs before looking up the referent within the schema path, to fix hex characters substituted in variable names. Use the output encoding from the configuration for URI parsing.
