### PR TITLE
Feature/no pluralization

### DIFF
--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ArrayRule.java
@@ -78,7 +78,7 @@ public class ArrayRule implements Rule<JPackage, JClass> {
 
         JType itemType;
         if (node.has("items")) {
-            itemType = ruleFactory.getSchemaRule().apply(makeSingular(nodeName), node.get("items"), jpackage, schema);
+            itemType = ruleFactory.getSchemaRule().apply(nodeName, node.get("items"), jpackage, schema);
         } else {
             itemType = jpackage.owner().ref(Object.class);
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/EnumRule.java
@@ -39,6 +39,7 @@ import org.jsonschema2pojo.Schema;
 import org.jsonschema2pojo.SchemaMapper;
 import org.jsonschema2pojo.exception.ClassAlreadyExistsException;
 import org.jsonschema2pojo.exception.GenerationException;
+import org.jsonschema2pojo.util.NameHelper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -232,7 +233,7 @@ public class EnumRule implements Rule<JClassContainer, JType> {
 
     private String getEnumName(String nodeName, JsonNode node, JClassContainer container) {
         String fieldName = ruleFactory.getNameHelper().getFieldName(nodeName, node);
-        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(capitalize(fieldName));
+        String className = NameHelper.replaceIllegalCharacters(capitalize(fieldName));
         String normalizedName = ruleFactory.getNameHelper().normalizeName(className);
         // suffix enum names with "Enum" to avoid name clash with capitalized field names
         return makeUnique(normalizedName + "Enum", container);
@@ -262,9 +263,9 @@ public class EnumRule implements Rule<JClassContainer, JType> {
 
         List<String> enumNameGroups = new ArrayList<String>(asList(splitByCharacterTypeCamelCase(nodeName)));
 
-        String enumName = "";
+        String enumName;
         for (Iterator<String> iter = enumNameGroups.iterator(); iter.hasNext();) {
-            if (containsOnly(ruleFactory.getNameHelper().replaceIllegalCharacters(iter.next()), "_")) {
+            if (containsOnly(NameHelper.replaceIllegalCharacters(iter.next()), "_")) {
                 iter.remove();
             }
         }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/ObjectRule.java
@@ -542,7 +542,7 @@ public class ObjectRule implements Rule<JPackage, JType> {
         String capitalizedFieldName = capitalize(fieldName);
         String fullFieldName = createFullFieldName(capitalizedFieldName, prefix, suffix);
 
-        String className = ruleFactory.getNameHelper().replaceIllegalCharacters(fullFieldName);
+        String className = NameHelper.replaceIllegalCharacters(fullFieldName);
         String normalizedName = ruleFactory.getNameHelper().normalizeName(className);
         return makeUnique(normalizedName, _package);
     }

--- a/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
+++ b/jsonschema2pojo-core/src/main/java/org/jsonschema2pojo/rules/PropertyRule.java
@@ -29,6 +29,7 @@ import com.sun.codemodel.JVar;
 
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.Schema;
+import org.jsonschema2pojo.util.NameHelper;
 
 import static org.apache.commons.lang3.StringUtils.capitalize;
 
@@ -203,7 +204,7 @@ public class PropertyRule implements Rule<JDefinedClass, JDefinedClass> {
     }
 
     private String getBuilderName(String propertyName) {
-        propertyName = ruleFactory.getNameHelper().replaceIllegalCharacters(propertyName);
+        propertyName = NameHelper.replaceIllegalCharacters(propertyName);
         return "with" + capitalize(ruleFactory.getNameHelper().capitalizeTrailingWords(propertyName));
     }
 


### PR DESCRIPTION
Do not use pluralized/singularized versions of type names, to ease introspection.

Although methods for pluralizing exist, it appears only singularization is in use, and only in the case of array types.
